### PR TITLE
Fix for bad MM patch related to FAR

### DIFF
--- a/GameData/QuizTechAeroContinued/MM_Patches/quizTech_aero_FAR.cfg
+++ b/GameData/QuizTechAeroContinued/MM_Patches/quizTech_aero_FAR.cfg
@@ -65,7 +65,7 @@
     !MODULE[ModuleLiftingSurface] {}
 }
 
-@PART[quizTechVTOLwing]:NEEDS[FerramAerospaceResearch]:FOR[FerramAerospaceResearch]
+@PART[quizTechVTOLwing]:NEEDS[FerramAerospaceResearch]:BEFORE[FerramAerospaceResearch]
 {
     @module = Part
     @maximum_drag = 0
@@ -77,7 +77,7 @@
     %MODULE[FARWingAerodynamicModel]
     {
         %b_2 = 3.5
-        %MAC = 1.9 // this is basically wrong, but actual value should be somethere around
+        %MAC = 1.9 // this is basically wrong, but actual value should be somewhere around these
         %TaperRatio = 0.5
         %MidChordSweep = 26.57
     }


### PR DESCRIPTION
Using FOR[FerramAerospaceResearch] result in MM seeing FAR mod as present no matter what. This caused multiple issues with other mod checking for the presence of FerramAerospaceResearch...
