### PR TITLE
Update Mk2MedNose.cfg

### DIFF
--- a/GameData/QuizTechAeroContinued/Parts/Structural/Mk2_Med_Nose/Mk2MedNose.cfg
+++ b/GameData/QuizTechAeroContinued/Parts/Structural/Mk2_Med_Nose/Mk2MedNose.cfg
@@ -1,64 +1,60 @@
 PART
 {
+	name = mk2MedNose
+	module = Part
+	author = Quiznos323
 
-name = mk2MedNose
-module = Part
-author = Quiznos323
+	MODEL
+	{
+		model = QuizTechAeroContinued/Parts/Command/Mk2ProbeNose/Mk2ProbeNose
+		position = 0.0, 0.0, 0.0
+		scale = 1,1,1
+		rotation = 0, 0, 0
+		texture = Mk2NoseProbeLUM, QuizTechAeroContinued/Parts/Structural/Mk2_Med_Nose/blank
+	}
+	scale = 1.0
+	rescaleFactor = 1
 
-MODEL
-{
-	model = QuizTechAeroContinued/Parts/Command/Mk2ProbeNose/Mk2ProbeNose
-	position = 0.0, 0.0, 0.0
-	scale = 1,1,1
-	rotation = 0, 0, 0
-	texture = blank, QuizTechAeroContinued/Parts/Command/Mk2ProbeNose/Mk2NoseProbe
-}
-scale = 1.0
-rescaleFactor = 1
-	
-node_stack_bottom = 0.0, -1.05, -0.044, 0.0, -1.0, 0.0
+	node_stack_bottom = 0.0, -1.05, -0.044, 0.0, -1.0, 0.0
 
-TechRequired = supersonicFlight
-entryCost = 7000
-cost = 550
-category = Aero
-subcategory = 0
-title = Mk2 Medium Nose
-manufacturer = Quiztech Aerodynamics Division
-description = A medium nose for capping Mk2 body sections.
+	TechRequired = supersonicFlight
+	entryCost = 7000
+	cost = 550
+	category = Aero
+	subcategory = 0
+	title = Mk2 Medium Nose
+	manufacturer = Quiztech Aerodynamics Division
+	description = A medium nose for capping Mk2 body sections.
 
-// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
-attachRules = 1,0,1,1,0
+	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+	attachRules = 1,0,1,1,0
 
-// --- standard part parameters ---
-mass = 0.1
-dragModelType = override
-maximum_drag = 0.2
-minimum_drag = 0.1
-angularDrag = 2
-crashTolerance = 40
-breakingForce = 200
-breakingTorque = 200
-maxTemp = 3000
-fuelCrossFeed = True
-bulkheadProfiles = srf, mk2
+	// --- standard part parameters ---
+	mass = 0.1
+	dragModelType = override
+	maximum_drag = 0.2
+	minimum_drag = 0.1
+	angularDrag = 2
+	crashTolerance = 40
+	breakingForce = 200
+	breakingTorque = 200
+	maxTemp = 3000
+	fuelCrossFeed = True
+	bulkheadProfiles = srf, mk2
 
-tags = fueltank ?lfo liquid oxidizer propellant rocket aero )cap drag fligh speed stream
+	tags = fueltank ?lfo liquid oxidizer propellant rocket aero )cap drag fligh speed stream
 
-MODULE
-{
-	name = ModuleLiftingSurface
-	
-	deflectionLiftCoeff = 0.6
-	dragAtMaxAoA = 0.1
-	dragAtMinAoA = 0.03
-}
-
-RESOURCE
-{
- name = LiquidFuel
- amount = 400
- maxAmount = 400
-}
-
+	MODULE
+	{
+		name = ModuleLiftingSurface	
+		deflectionLiftCoeff = 0.6
+		dragAtMaxAoA = 0.1
+		dragAtMinAoA = 0.03
+	}
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 400
+		maxAmount = 400
+	}
 }


### PR DESCRIPTION
Fixed invalid texture reference.

**linuxgurugamer: Don't forget to replace the file "blank.dds" with the one I provided (a black 2x2, no mipmaps, DXT1) or the part will appear bathed in blue light!**
