### PR TITLE
Update Mk2_LinAerospike.cfg

### DIFF
--- a/GameData/QuizTechAeroContinued/Parts/Engine/mk2_LinAerospike/Mk2_LinAerospike.cfg
+++ b/GameData/QuizTechAeroContinued/Parts/Engine/mk2_LinAerospike/Mk2_LinAerospike.cfg
@@ -61,7 +61,7 @@ entryCost = 31000
 cost = 5500
 category = Engine
 subcategory = 0
-title = QuizTech Mk2 Linear Aerospike Rocket
+title = Mk2 Linear Aerospike Rocket
 manufacturer = QuizTech Aerodynamics Division
 description = On the cutting edge of spaceplane technology, the linear aerospike rocket surpasses the performance and reliability of the standard rocket engine.
 


### PR DESCRIPTION
Removed "QuizTech" in the title for consistency. Was the only engine starting with that word.
